### PR TITLE
Add sanitize to application layout for flash messages

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,8 @@
 exit
+@staches
+continue
+@staches
+exit
 msg
 continue
 msg

--- a/app/controllers/cart_staches_controller.rb
+++ b/app/controllers/cart_staches_controller.rb
@@ -11,8 +11,8 @@ class CartStachesController < ApplicationController
     @cart.delete_stache(stache.id)
     session[:cart] = @cart.contents
     stache_link = view_context.link_to stache.name, stache_path(stache)
-    flash.now[:removed] =
+    flash[:removed] =
     "Successfully removed #{stache_link} from your cart.".html_safe
-    render "carts/show"
+    redirect_to cart_path
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 </nav>
 
 <% flash.each do |type, msg| %>
-  <%= content_tag :div, msg, class: "flash_#{type}" %>
+  <%= content_tag :div, sanitize(msg), class: "flash_#{type}" %>
 <% end %>
 
 <%= yield %>


### PR DESCRIPTION
Our render on removing an item from the cart didn't pass the instance variable @staches so any items left in the cart would no longer display after removing another item from the cart. I changed it back to a redirect, as we discussed earlier, and added a sanitize method on the flash message within the application.html.erb in the layout views folder.
