### PR TITLE
80 change delete to retire and styling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -35,6 +35,10 @@ a {
   font-family: 'Unica One';
 }
 
+.flash {
+  padding-left: 10px;
+}
+
 footer {
    position:inherit;
    bottom: 0;

--- a/app/controllers/admin/staches_controller.rb
+++ b/app/controllers/admin/staches_controller.rb
@@ -35,9 +35,13 @@ module Admin
       end
     end
 
-
     def retire
       Stache.update(params[:stache_id], retired: true)
+      redirect_to admin_staches_path
+    end
+
+    def activate
+      Stache.update(params[:stache_id], retired: false)
       redirect_to admin_staches_path
     end
 

--- a/app/controllers/admin/staches_controller.rb
+++ b/app/controllers/admin/staches_controller.rb
@@ -35,6 +35,12 @@ module Admin
       end
     end
 
+
+    def retire
+      Stache.update(params[:stache_id], retired: true)
+      redirect_to admin_staches_path
+    end
+
     private
 
     def stache_params

--- a/app/views/admin/staches/index.html.erb
+++ b/app/views/admin/staches/index.html.erb
@@ -25,7 +25,9 @@
         <td>
           <%= link_to "Edit", edit_admin_stache_path(stache) %>
           <%= link_to "Retire", admin_retire_stache_path(stache_id: stache.id), method: :put,
-                      id: "stache-#{stache.id}-retire" %>
+                      id: "stache-#{stache.id}-retire" unless stache.retired? %>
+          <%= link_to "Activate", admin_activate_stache_path(stache_id: stache.id), method: :put,
+                      id: "stache-#{stache.id}-activate" if stache.retired? %>
         </td>
       </tr>
     </div>

--- a/app/views/admin/staches/index.html.erb
+++ b/app/views/admin/staches/index.html.erb
@@ -24,7 +24,8 @@
         <td><%= stache.status %></td>
         <td>
           <%= link_to "Edit", edit_admin_stache_path(stache) %>
-          <%= link_to "Delete", admin_stache_path(stache), method: :delete %>
+          <%= link_to "Retire", admin_retire_stache_path(stache_id: stache.id), method: :put,
+                      id: "stache-#{stache.id}-retire" %>
         </td>
       </tr>
     </div>

--- a/app/views/admin/staches/index.html.erb
+++ b/app/views/admin/staches/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
 <h4>You are the Stache Master</h4>
-<%= link_to "Add New Stache", new_admin_stache_path %>
+<%= link_to "Add New Stache", new_admin_stache_path, class: "btn light-green darken-4" %>
 <table>
   <thead>
     <tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
   </div>
 
 <% flash.each do |type, msg| %>
-  <%= content_tag :div, sanitize(msg), class: "flash_#{type}" %>
+  <%= content_tag :div, sanitize(msg), class: "flash_#{type} flash" %>
 <% end %>
 
 <%= yield %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container transparent">
-  <h3>Orders:</h3>
+  <h4>Orders:</h4>
 
   <table class="centered bordered responsive-table">
     <thead>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,23 +1,24 @@
 <div class="container">
   <%= form_for @order do |f| %>
+  <%= f.text_field :first_name %>
     <%= f.label :first_name, "First Name" %>
-    <%= f.text_field :first_name %>
 
-    <%= f.label :last_name, "Last Name" %>
     <%= f.text_field :last_name %>
+    <%= f.label :last_name, "Last Name" %>
 
-    <%= f.label :address %>
     <%= f.text_field :address %>
+    <%= f.label :address %>
 
-    <%= f.label :city %>
     <%= f.text_field :city %>
+    <%= f.label :city %>
 
-    <%= f.label :state %>
     <%= f.text_field :state %>
+    <%= f.label :state %>
 
-    <%= f.label :zipcode %>
     <%= f.text_field :zipcode %>
-    
-    <%= f.submit "Submit Order" %>
+    <%= f.label :zipcode %>
+    <br>
+    <br>
+    <%= f.submit "Submit Order", class: "btn light-green darken-4" %>
   <% end %>
 </div>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -3,7 +3,7 @@
   <p>
     Welcome <%= @user.username %>!
   </p>
-  <%= link_to "Order History", orders_path, class: "btn" %>
+  <%= link_to "Order History", orders_path, class: "btn light-green darken-4" %>
 
-  <%= link_to "Edit Account Info", edit_user_path(@user), class: "btn" %>
+  <%= link_to "Edit Account Info", edit_user_path(@user), class: "btn light-green darken-4" %>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h3>Edit Account Info</h3>
+  <h4>Edit Account Info</h4>
   <%= form_for(@user) do |f| %>
     <%= render "shared/error_messages", object: f.object %>
 
@@ -14,6 +14,6 @@
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation %>
 
-    <%= f.submit "Update Account", class: "wave-effect waves-light btn" %>
+    <%= f.submit "Update Account", class: "wave-effect waves-light btn light-green darken-4" %>
   <% end  %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     put "cancel_order", to: "orders#cancel"
     put "paid_order", to: "orders#paid"
     put "complete_order", to: "orders#complete"
+    put "retire_stache", to: "staches#retire"
   end
 
   resources :cart_staches, only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     put "paid_order", to: "orders#paid"
     put "complete_order", to: "orders#complete"
     put "retire_stache", to: "staches#retire"
+    put "activate_stache", to: "staches#activate"
   end
 
   resources :cart_staches, only: [:create, :destroy]

--- a/test/integration/admin_retires_stache_from_index_test.rb
+++ b/test/integration/admin_retires_stache_from_index_test.rb
@@ -17,4 +17,21 @@ class AdminRetiresStacheFromIndexTest < ActionDispatch::IntegrationTest
       refute page.has_content?("Active")
     end
   end
+
+  test "admin clicks on activate and the item is updated to active" do
+    admin = User.create(username: "admin", password: "pw", role: 1)
+    stache = create(:stache, name: "Chaplin", price: 4, description: "kljdf",
+                             retired: true)
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit admin_staches_path
+
+    click_on "stache-#{stache.id}-activate"
+    refute Stache.find(stache.id).retired
+
+    within("#stache-#{stache.id}") do
+      assert page.has_content?("Active")
+      refute page.has_content?("Retired")
+    end
+  end
 end

--- a/test/integration/admin_retires_stache_from_index_test.rb
+++ b/test/integration/admin_retires_stache_from_index_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class AdminRetiresStacheFromIndexTest < ActionDispatch::IntegrationTest
   test "admin clicks on retire and the item is updated to retired" do

--- a/test/integration/admin_retires_stache_from_index_test.rb
+++ b/test/integration/admin_retires_stache_from_index_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class AdminRetiresStacheFromIndexTest < ActionDispatch::IntegrationTest
+  test "admin clicks on retire and the item is updated to retired" do
+    admin = User.create(username: "admin", password: "pw", role: 1)
+    stache = create(:stache, name: "Chaplin", price: 4, description: "kljdf",
+                             retired: false)
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit admin_staches_path
+
+    click_on "stache-#{stache.id}-retire"
+    assert Stache.find(stache.id).retired
+
+    within("#stache-#{stache.id}") do
+      assert page.has_content?("Retired")
+      refute page.has_content?("Active")
+    end
+  end
+end


### PR DESCRIPTION
Connects to #89 and connects to #88 and connects to #77 and connects to #78 and connects to #87 and connects to #73.

This branch changes the "delete" button on the admin staches index page to a retired or activate button. Also added styling for unstyled headers and buttons.
