### PR TITLE
Add restriction for stache creation 

### DIFF
--- a/app/models/stache_creation.rb
+++ b/app/models/stache_creation.rb
@@ -11,7 +11,7 @@ class StacheCreation
     if status == 1
       @stache.retired = true
     end
-    @stache.categories << Category.find(categories)
+    @stache.categories << Category.find(categories) unless categories.nil?
     stache.save
   end
 end

--- a/app/views/admin/staches/edit.html.erb
+++ b/app/views/admin/staches/edit.html.erb
@@ -1,2 +1,3 @@
+<h4>Make That Stache Even Stachier</h4>
 <% provide(:button_text, "Update Stache") %>
 <%= render "form" %>

--- a/app/views/admin/staches/new.html.erb
+++ b/app/views/admin/staches/new.html.erb
@@ -1,2 +1,3 @@
+<h4>Brand Spankin' New Stache</h4>
 <% provide(:button_text, "Create New Stache") %>
 <%= render "form" %>

--- a/app/views/admin/staches/new.html.erb
+++ b/app/views/admin/staches/new.html.erb
@@ -1,3 +1,5 @@
-<h4>Brand Spankin' New Stache</h4>
-<% provide(:button_text, "Create New Stache") %>
-<%= render "form" %>
+<div class="container">
+  <h4 class="center">Brand Spankin' New Stache</h4>
+  <% provide(:button_text, "Create New Stache") %>
+  <%= render "form" %>
+</div>


### PR DESCRIPTION
so that categories aren't added to stache if they are nil. Previously this caused an error as categories couldn't find any associated with a nil selection. It now fails on validation that requires presence of categories rather than creating server error.

closes #102 
